### PR TITLE
Undo fit to content

### DIFF
--- a/licit/client/index.js
+++ b/licit/client/index.js
@@ -29,7 +29,7 @@ function main(): void {
   const plugins = null;
   ReactDOM.render(<Licit docID={0} debug={false} width={'100vw'} height={'100vh'}
     onChange={onChangeCB} onReady={onReadyCB} data={docJSON} embedded={false} 
-    runtime={null} plugins={plugins} fitToContent={false} />, el);
+    runtime={null} plugins={plugins} />, el);
 }
 
 function onChangeCB(data) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@modusoperandi/licit",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modusoperandi/licit",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "subversion": "1",
   "description": "Rich text editor built with React and ProseMirror",
   "main": "dist/index.js",

--- a/src/client/Licit.js
+++ b/src/client/Licit.js
@@ -35,7 +35,6 @@ import './licit.css';
  *  disabled {boolean} [false] Disable the editor.
  *  embedded {boolean} [false] Disable/Enable inline behaviour.
  *  plugins [plugins] External Plugins into the editor.
- *  fitToContent {boolean} [false] Fit to content behavour.
  */
 class Licit extends React.Component<any, any> {
   _runtime: EditorRuntime;
@@ -69,7 +68,6 @@ class Licit extends React.Component<any, any> {
     const data = props.data || null;
     const disabled = props.disabled || false;
     const embedded = props.embedded || false;// [FS] IRAD-996 2020-06-30
-    const fitToContent = props.fitToContent || false;// [FS] IRAD-996 2020-06-30
     // [FS] 2020-07-03
     // Handle Image Upload from Angular App
     const runtime = props.runtime ? props.runtime : new LicitRuntime();
@@ -101,7 +99,6 @@ class Licit extends React.Component<any, any> {
       debug,
       disabled,
       embedded,
-      fitToContent,
       runtime
     };
     // FS IRAD-1040 2020-26-08
@@ -183,7 +180,7 @@ class Licit extends React.Component<any, any> {
   }
 
   render(): React.Element<any> {
-    const { editorState, width, height, readOnly, disabled, embedded, fitToContent, runtime } = this.state;
+    const { editorState, width, height, readOnly, disabled, embedded, runtime } = this.state;
     // [FS] IRAD-978 2020-06-05
     // Using 100vw & 100vh (100% viewport) is not ideal for a component which is expected to be a part of a page,
     // so changing it to 100%  width & height which will occupy the area relative to its parent.
@@ -191,7 +188,6 @@ class Licit extends React.Component<any, any> {
       <RichTextEditor
         editorState={editorState}
         embedded={embedded}
-        fitToContent={fitToContent}
         height={height}
         onChange={this._onChange}
         onReady={this._onReady}
@@ -254,7 +250,6 @@ class Licit extends React.Component<any, any> {
   *  data {JSON} [null] Document data to be loaded into the editor.
   *  disabled {boolean} [false] Disable the editor.
   *  embedded {boolean} [false] Disable/Enable inline behaviour.
-  * fitToContent {boolean} [false] Fit to content behavour.
   */
   setProps = (props: any): void => {
     if (this.state.readOnly) {

--- a/src/client/Licit.js
+++ b/src/client/Licit.js
@@ -60,8 +60,9 @@ class Licit extends React.Component<any, any> {
     const docID = props.docID || 0; // 0 < means collaborative.
     const collaborative = 0 < docID;
     const debug = props.debug || false;
-    const width = props.width || '100%';
-    const height = props.height || '100%';
+    // Default width and height to undefined
+    const width = props.width || undefined;
+    const height = props.height || undefined;
     const onChangeCB = (typeof props.onChange === 'function') ? props.onChange : noop;
     const onReadyCB = (typeof props.onReady === 'function') ? props.onReady : noop;
     const readOnly = props.readOnly || false;

--- a/src/ui/Editor.js
+++ b/src/ui/Editor.js
@@ -43,7 +43,6 @@ export type EditorProps = {
   dispatchTransaction?: ?(tr: Transform) => void,
   editorState?: ?EditorState,
   embedded?: ?boolean,
-  fitToContent?: ?boolean,
   onBlur?: ?() => void,
   onChange?: ?(state: EditorState) => void,
   onReady?: ?(view: EditorView) => void,
@@ -235,15 +234,8 @@ class Editor extends React.PureComponent<any, any> {
   }
 
   render(): React.Element<any> {
-    const { embedded, fitToContent, readOnly } = this.props;
-    let className = '';
-    //  FS IRAD-1040 2020-17-09
-    //  wrapping style for fit to content mode
-    if (fitToContent) {
-      className = cx('prosemirror-editor-wrapper', { fitToContent, readOnly });
-    } else {
-      className = cx('prosemirror-editor-wrapper', { embedded, readOnly });
-    }
+    const { embedded, readOnly } = this.props;
+    const className = cx('prosemirror-editor-wrapper', { embedded, readOnly });
     return (
       <div
         className={className}

--- a/src/ui/EditorFrameset.js
+++ b/src/ui/EditorFrameset.js
@@ -18,13 +18,15 @@ export type EditorFramesetProps = {
 export const FRAMESET_BODY_CLASSNAME = 'czi-editor-frame-body';
 
 function toCSS(val: ?(number | string)): string {
-  if (typeof val === 'number') {
-    return val + 'px';
+  if (!val || val === 'auto') {
+    // '', 0, null, false, 'auto' are all treated as undefined
+    // instead of auto... 
+    return undefined;
   }
-  if (val === undefined || val === null) {
-    return 'auto';
+  if (isNaN(val)) {
+    return `${val}`;
   }
-  return String(val);
+  return `${val}px`;
 }
 
 class EditorFrameset extends React.PureComponent<any, any> {
@@ -42,18 +44,18 @@ class EditorFrameset extends React.PureComponent<any, any> {
       width,
     } = this.props;
 
-    const useFixedLayout = width !== undefined || height !== undefined;
+    const mainStyle = {
+      width: toCSS(width),
+      height: toCSS(height),
+    };
 
     const mainClassName = cx(className, {
       'czi-editor-frameset': true,
-      'with-fixed-layout': useFixedLayout,
+      // Layout is fixed when either width or height is set.
+      'with-fixed-layout': mainStyle.width || mainStyle.height,
       embedded: embedded,
     });
 
-    const mainStyle = {
-      width: toCSS(width === undefined && useFixedLayout ? 'auto' : width),
-      height: toCSS(height === undefined && useFixedLayout ? 'auto' : height),
-    };
 
     const toolbarHeader =
       toolbarPlacement === 'header' || !toolbarPlacement ? toolbar : null;

--- a/src/ui/EditorFrameset.js
+++ b/src/ui/EditorFrameset.js
@@ -8,7 +8,6 @@ export type EditorFramesetProps = {
   body: ?React.Element<any>,
   className: ?string,
   embedded: ?boolean,
-  fitToContent: ?boolean,
   header: ?React.Element<any>,
   height: ?(string | number),
   toolbarPlacement?: 'header' | 'body' | null,
@@ -41,27 +40,15 @@ class EditorFrameset extends React.PureComponent<any, any> {
       toolbarPlacement,
       toolbar,
       width,
-      fitToContent,
     } = this.props;
 
     const useFixedLayout = width !== undefined || height !== undefined;
-    let mainClassName = '';
-    //  FS IRAD-1040 2020-17-09
-    //  wrapping style for fit to content mode
-    if (fitToContent) {
-      mainClassName = cx(className, {
-        'czi-editor-frameset': true,
-        'with-fixed-layout': useFixedLayout,
-        fitToContent: fitToContent,
-      });
-    } else {
-      mainClassName = cx(className, {
-        'czi-editor-frameset': true,
-        'with-fixed-layout': useFixedLayout,
-        embedded: embedded,
-      });
-    }
 
+    const mainClassName = cx(className, {
+      'czi-editor-frameset': true,
+      'with-fixed-layout': useFixedLayout,
+      embedded: embedded,
+    });
 
     const mainStyle = {
       width: toCSS(width === undefined && useFixedLayout ? 'auto' : width),

--- a/src/ui/RichTextEditor.js
+++ b/src/ui/RichTextEditor.js
@@ -56,7 +56,6 @@ class RichTextEditor extends React.PureComponent<any, any> {
       placeholder,
       readOnly,
       width,
-      fitToContent,
     } = this.props;
 
     let {editorState, runtime} = this.props;
@@ -85,7 +84,6 @@ class RichTextEditor extends React.PureComponent<any, any> {
           dispatchTransaction={this._dispatchTransaction}
           editorState={editorState}
           embedded={embedded}
-          fitToContent={fitToContent}
           id={this._id}
           nodeViews={nodeViews}
           onChange={onChange}
@@ -103,7 +101,6 @@ class RichTextEditor extends React.PureComponent<any, any> {
         body={body}
         className={className}
         embedded={embedded}
-        fitToContent={fitToContent}
         header={header}
         height={height}
         toolbar={toolbar}

--- a/src/ui/czi-editor-frameset.css
+++ b/src/ui/czi-editor-frameset.css
@@ -23,11 +23,7 @@
 .czi-editor-frameset.embedded .czi-editor-frame-body-scroll {
   padding-top: unset;
 }
- /* FS IRAD-1040 2020-17-09
- avoid padding top for fit to content propery  */
-.czi-editor-frameset.fitToContent .czi-editor-frame-body-scroll {
-  padding-top: 0px;
-}
+
 .czi-editor-frameset.with-fixed-layout .czi-editor-frame-main {
   display: flex;
   flex-direction: column;

--- a/src/ui/czi-editor.css
+++ b/src/ui/czi-editor.css
@@ -109,17 +109,6 @@
   width: unset;
 }
 
-/* FS IRAD-1040 2020-17-09
-  fit to content style  */
-.prosemirror-editor-wrapper.fitToContent .ProseMirror {
-  background: white;
-  border-radius: unset;
-   min-height: unset;
-  padding: 5px;
-  width: unset;
-  margin-bottom: 5px;
-}
-
 @media only print {
   .ProseMirror.ProseMirror[class] {
     border-radius: unset;


### PR DESCRIPTION
Reverses recent updates that added fitToContent property.

Reverses changes to width and height handling that caused .with-fixed-layout to be unconditionally added to editor tags.  This should restore the original dynamic layout that was already built into editor code.