### PR TITLE
Bugfix/css collision accordion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@modusoperandi/licit",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modusoperandi/licit",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "subversion": "1",
   "description": "Rich text editor built with React and ProseMirror",
   "main": "dist/index.js",

--- a/src/ui/CustomStyleEditor.js
+++ b/src/ui/CustomStyleEditor.js
@@ -346,7 +346,7 @@ class CustomStyleEditor extends React.PureComponent<any, any> {
   }
 
   componentDidMount() {
-    const acc = document.getElementsByClassName('accordion');
+    const acc = document.getElementsByClassName('licit-accordion');
     let i;
 
     for (i = 0; i < acc.length; i++) {
@@ -463,7 +463,7 @@ class CustomStyleEditor extends React.PureComponent<any, any> {
                 border: '1px solid',
               }}
             >
-              <button className="accordion accactive" id="accordion1">
+              <button className="licit-accordion accactive" id="accordion1">
                 <div className="indentdiv">
                   <span
                     className="iconspan czi-icon text_format"
@@ -689,7 +689,7 @@ class CustomStyleEditor extends React.PureComponent<any, any> {
                   </span>
                 </div>
               </div>
-              <button className="accordion accactive">
+              <button className="licit-accordion accactive">
                 <div className="indentdiv">
                   <span
                     className="iconspan czi-icon format_textdirection_l_to_r"
@@ -844,7 +844,7 @@ class CustomStyleEditor extends React.PureComponent<any, any> {
                   <label style={{ marginLeft: '3px' }}>pts</label>
                 </div>
               </div>
-              <button className="accordion accactive">
+              <button className="licit-accordion accactive">
                 <div className="indentdiv">
                   <span className="iconspan czi-icon account_tree">
                     account_tree

--- a/src/ui/custom-style-edit.css
+++ b/src/ui/custom-style-edit.css
@@ -267,7 +267,7 @@ label {
     display: none;
 }
 
-.accordion {
+.licit-accordion {
     background-color: #ccc;
     border-color: lightgray;
     border-style: solid;
@@ -283,7 +283,7 @@ label {
     width: 100%;
 }
 
-.accordion:after {
+.licit-accordion:after {
     color: #777;
     content: '\002B';
     float: right;


### PR DESCRIPTION
Renames .accordion to .licit-accordion to avoid collision with global bootstrap style of the same name.

This is a band-aid fix, since component level styles should never be placed in the global space.