### PR TITLE
Bugfix/restore editor view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@modusoperandi/licit",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modusoperandi/licit",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "subversion": "1",
   "description": "Rich text editor built with React and ProseMirror",
   "main": "dist/index.js",

--- a/src/client/Licit.js
+++ b/src/client/Licit.js
@@ -45,6 +45,13 @@ class Licit extends React.Component<any, any> {
 
   _popUp = null;
 
+  /**
+   * Provides access to prosemirror view.
+   */
+  get editorView(): EditorView {
+    return this._editorView;
+  }
+
   constructor(props: any, context: any) {
     super(props, context);
 


### PR DESCRIPTION
Restores read-only property "editorView" on licit component removed by recent commits.