### PR TITLE
Bugfix/async init

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@modusoperandi/licit",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modusoperandi/licit",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "subversion": "1",
   "description": "Rich text editor built with React and ProseMirror",
   "main": "dist/index.js",

--- a/src/Types.js
+++ b/src/Types.js
@@ -183,10 +183,6 @@ export type EditorRuntime = {
   getStylesAsync: () => Promise<StyleProps[]>,
 
   /**
-   * Gets array of styles from the service
-   */
-  fetchStyles: () => Promise<StyleProps[]>,
-  /**
    * Renames an existing style from the service.
    * @param oldStyleName
    * @param newStyleName

--- a/src/client/Licit.test.js
+++ b/src/client/Licit.test.js
@@ -15,6 +15,7 @@ configure({
 describe('<Licit />', () => {
   let wrapper;
   let licit;
+  let runtime;
 
   // Mocking the functions used in _onReady
   const fakeEditorView = {
@@ -60,6 +61,60 @@ describe('<Licit />', () => {
 
       // Verify that getter now returns the underlying view.
       expect(licit.editorView).toBe(fakeEditorView);
+    });
+  });
+
+  describe('loadStyles', () => {
+    let warn;
+
+    beforeEach(() => (warn = jest.spyOn(console, 'warn').mockReturnValue()));
+    afterEach(() => warn.mockRestore());
+
+    describe('when props does not contain a runtime', () => {
+      it('should invoke initialize', async () => {
+        // Mock runtime to not use styles.
+        runtime = {};
+        wrapper = shallow(<Licit runtime={runtime} />);
+        const spy = jest.spyOn(wrapper.instance(), 'initialize');
+
+        // wait 100ms for setTimeout inside constructor to complete
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        expect(spy).toHaveBeenCalled();
+        expect(warn).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when styles are fetched successfully', () => {
+      it('should invoke initialize', async () => {
+        // Mock runtime to succeed.
+        runtime = { getStylesAsync: jest.fn().mockResolvedValue([]) };
+        wrapper = shallow(<Licit runtime={runtime} />);
+        const spy = jest.spyOn(wrapper.instance(), 'initialize');
+
+        // wait 100ms for setTimeout inside constructor to complete
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        expect(runtime.getStylesAsync).toHaveBeenCalled();
+        expect(spy).toHaveBeenCalled();
+        expect(warn).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when style request fails', () => {
+      it('should invoke initialize', async () => {
+        // Mock runtime to fail.
+        runtime = { getStylesAsync: jest.fn().mockRejectedValue('boom') };
+        wrapper = shallow(<Licit runtime={runtime} />);
+        const spy = jest.spyOn(wrapper.instance(), 'initialize');
+
+        // wait 100ms for setTimeout inside constructor to complete
+        await new Promise((resolve) => setTimeout(resolve, 100));
+
+        expect(runtime.getStylesAsync).toHaveBeenCalled();
+        expect(spy).toHaveBeenCalled();
+        expect(warn).toHaveBeenCalled();
+      });
     });
   });
 });


### PR DESCRIPTION
Fixes issue loading editor triggered by improper use of react setState followed by access to this.state.  See [docs](https://reactjs.org/docs/react-component.html#setstate)

Fixes private fetchStyles being called directly by editor instead of public getStylesAsync.

Adds TODO to remove side effect code from runtime.