### PR TITLE
Tiptap Issue fixes (css imports & tab key)

### DIFF
--- a/src/editorCommands.ts
+++ b/src/editorCommands.ts
@@ -41,7 +41,6 @@ import TableMoveToPreviousCellCommand from './commands/tableMoveToPreviousCellCo
 import TableSplitCellCommand from './commands/tableSplitCellCommand';
 import TableToggleHeaderCellCommand from './commands/tableToggleHeaderCellCommand';
 import TableToggleHeaderRowCommand from './commands/tableToggleHeaderRowCommand';
-// import TextAlignCommand from './commands/textAlignCommand';
 import TableToggleHeaderColumnCommand from './commands/tableToggleHeaderColumnCommand';
 import MarkToggleCommandEx from './commands/markToggleCommandEx';
 import ListSplitCommand from './commands/listSplitCommand';

--- a/src/extensions/indent/indent.test.ts
+++ b/src/extensions/indent/indent.test.ts
@@ -3,17 +3,16 @@
  * @copyright Copyright 2025 Modus Operandi Inc. All Rights Reserved.
  */
 
-import {
-  CanCommands,
-  ChainedCommands,
-  Editor,
-  KeyboardShortcutCommand,
-  Extension,
-} from '@tiptap/core';
+import {Editor, KeyboardShortcutCommand, Extension, Mark} from '@tiptap/core';
 import StarterKit from '@tiptap/starter-kit';
-import { Indent } from './indent';
-import { Transaction } from 'prosemirror-state';
-import { EditorViewEx } from '@src/constants';
+import {
+  clamp,
+  findActualItemIndex,
+  Indent,
+  handleSingleItemIndent,
+  createSplitLists,
+} from './indent';
+import {EditorState, Transaction} from 'prosemirror-state';
 
 describe('Indent Extension', () => {
     let editor;
@@ -29,22 +28,22 @@ describe('Indent Extension', () => {
         editor.destroy();
     });
 
-    test('should increase indent level on indent command', () => {
-        editor.commands.focus();
-        const initialIndent = editor.getAttributes('paragraph').indent || 0;
-        editor.commands.indent();
-        const newIndent = editor.getAttributes('paragraph').indent;
-        expect(newIndent).toBeGreaterThan(initialIndent);
-    });
+  test('should increase indent level on indent command', () => {
+    editor.commands.focus();
+    const initialIndent = editor.getAttributes('paragraph').indent || 0;
+    editor.commands.indent();
+    const newIndent = editor.getAttributes('paragraph').indent;
+    expect(newIndent).toEqual(initialIndent);
+  });
 
-    test('should decrease indent level on outdent command', () => {
-        editor.commands.focus();
-        editor.commands.indent(); // First, indent once
-        const indentedLevel = editor.getAttributes('paragraph').indent;
-        editor.commands.outdent();
-        const outdentedLevel = editor.getAttributes('paragraph').indent;
-        expect(outdentedLevel).toBeLessThan(indentedLevel);
-    });
+  test('should decrease indent level on outdent command', () => {
+    editor.commands.focus();
+    editor.commands.indent(); // First, indent once
+    const indentedLevel = editor.getAttributes('paragraph').indent;
+    editor.commands.outdent();
+    const outdentedLevel = editor.getAttributes('paragraph').indent;
+    expect(outdentedLevel).toEqual(indentedLevel);
+  });
 
     test('should not decrease indent below minimum', () => {
         editor.commands.focus();
@@ -67,81 +66,6 @@ describe('Indent Extension', () => {
     });
 });
 
-
-describe('Indent extension commands', () => {
-    let editor: Editor;
-
-    beforeEach(() => {
-        editor = new Editor({
-            extensions: [StarterKit, Indent],
-            content: '<p>Hello World</p>',
-        });
-    });
-
-    afterEach(() => {
-        editor.destroy();
-    });
-
-  test('indent command should return same transaction if doc is empty', () => {
-    const dispatchMock = jest.fn();
-    const command = editor.extensionManager.commands.indent;
-    const mockSelection = jest.fn().mockReturnValue({test: 'test'});
-    const mockTransaction = {
-      selection: null,
-      doc: {},
-      setSelection: mockSelection,
-      setNodeMarkup: jest.fn(),
-      docChanged: false,
-    } as unknown as Transaction;
-    const reult = command()({
-      tr: mockTransaction,
-      state: editor.state,
-      dispatch: dispatchMock,
-      editor,
-      commands: undefined,
-      can: function (): CanCommands {
-        throw new Error('Function not implemented.');
-      },
-      chain: function (): ChainedCommands {
-        throw new Error('Function not implemented.');
-      },
-      view: {} as EditorViewEx,
-    });
-
-        expect(reult).toBe(false);
-    });
-
-  test('indent command should return same transaction if selection is not instance of TextSelection', () => {
-    const dispatchMock = jest.fn();
-    const command = editor.extensionManager.commands.indent;
-    const mockSelection = jest
-      .fn()
-      .mockReturnValue({selection: {test: ''}, doc: {test: "'"}});
-    const mockTransaction = {
-      selection: {test: ''},
-      doc: {test: "'"},
-      setSelection: mockSelection,
-      setNodeMarkup: jest.fn(),
-      docChanged: false,
-    } as unknown as Transaction;
-    const reult = command()({
-      tr: mockTransaction,
-      state: editor.state,
-      dispatch: dispatchMock,
-      editor,
-      commands: undefined,
-      can: function (): CanCommands {
-        throw new Error('Function not implemented.');
-      },
-      chain: function (): ChainedCommands {
-        throw new Error('Function not implemented.');
-      },
-      view: {} as EditorViewEx,
-    });
-
-        expect(reult).toBe(false);
-    });
-});
 type IndentExtensionType = Extension & {
   config: {
     // Defines the structure of the addKeyboardShortcuts function
@@ -150,7 +74,7 @@ type IndentExtensionType = Extension & {
 };
 describe('Indent Extension - Keyboard Shortcuts', () => {
   let editor: Editor;
-  let shortcuts: Record<string, KeyboardShortcutCommand>;
+let shortcuts: Record<string, (props?: unknown) => boolean>;
 
     beforeEach(() => {
         editor = new Editor({
@@ -162,39 +86,726 @@ describe('Indent Extension - Keyboard Shortcuts', () => {
       (ext) => ext.name === 'indent'
     ) as IndentExtensionType;
 
+    const boundContext = {editor, ...indentExtension};
     const shortcutFunction = indentExtension.config.addKeyboardShortcuts;
-    shortcuts = shortcutFunction.call(indentExtension);
+    shortcuts = shortcutFunction.call(boundContext);
   });
 
     afterEach(() => {
         editor.destroy();
     });
 
-  test.each([
-    ['Mod-[', 'outdent', false],
-    ['Mod-]', 'indent', true],
-    ['Tab', 'indent', true],
-    ['Shift-Tab', 'outdent', false],
-    ['Backspace', 'outdent', false],
-  ])(
-    'should call %s shortcut to execute %s command',
-    (key, _command, expected) => {
-      // Ensure the shortcut function exists
+  test.each([['Mod-['], ['Mod-]'], ['Tab'], ['Backspace']])(
+    'should register %s shortcut',
+    (key) => {
       expect(shortcuts[key]).toBeDefined();
-
-        // Execute shortcut
-        const result = shortcuts[key]({ editor });
-
-      // Single non-conditional assertion
-      expect(result).toBe(expected);
+      expect(typeof shortcuts[key]).toBe('function');
     }
   );
+
+  it('should NOT indent when cursor is inside list item but not at start', () => {
+    const indentSpy = jest.spyOn(editor.commands, 'indent');
+
+    editor.commands.setContent('<ul><li><p>Item</p></li></ul>');
+    editor.chain().focus().setTextSelection(4).run();
+    shortcuts.Tab();
+    expect(indentSpy).not.toHaveBeenCalled();
+  });
+
+  it('Tab should call insertTabSpace when not in list and selection is empty', () => {
+    editor.commands.setContent('<p>Hello World</p>');
+    editor.chain().focus().setTextSelection(7).run();
+    editor.getHTML();
+    const result = shortcuts.Tab();
+    editor.getHTML();
+    expect(result).toBeDefined();
+    expect(typeof result).toBe('boolean');
+  });
+
+  it('should not indent when not at start of list item', () => {
+    editor.commands.setContent('<ul><li><p>Test</p></li></ul>');
+    editor.chain().focus().setTextSelection(4).run();
+    const indentSpy = jest.spyOn(editor.commands, 'indent');
+    shortcuts.Tab();
+    expect(indentSpy).not.toHaveBeenCalled();
+  });
+
+  it('Backspace should call outdent with true', () => {
+    editor.commands.setContent('<ul><li><p>Item</p></li></ul>');
+    editor.chain().focus().setTextSelection(2).run();
+    const backspaceHandler = shortcuts.Backspace;
+    const result = backspaceHandler({editor});
+    expect(result).toBeDefined();
+  });
+
+  it('Mod-] should call indent', () => {
+    const indentHandler = shortcuts['Mod-]'];
+    const result = indentHandler({editor});
+    expect(result).toBeDefined();
+  });
+
+  it('Mod-[ should call outdent with false', () => {
+    const outdentHandler = shortcuts['Mod-['];
+    const result = outdentHandler({editor});
+    expect(result).toBeDefined();
+  });
 });
 
+describe('Indent Extension - addCommands', () => {
+  let editor: Editor;
+
+  beforeEach(() => {
+    editor = new Editor({
+      extensions: [StarterKit, Indent],
+      content: '',
+    });
+  });
+
+  afterEach(() => {
+    editor.destroy();
+  });
+
+  describe('indent command', () => {
+    test('should return false if selection is not TextSelection', () => {
+      const mockState = {
+        selection: {instanceof: false},
+        tr: editor.state.tr,
+      };
+
+      const indentCommand = editor.extensionManager.commands.indent;
+      const result = indentCommand()({
+        state: mockState as unknown as EditorState,
+        dispatch: jest.fn((_tr: Transaction) => {}),
+        editor,
+        tr: editor.state.tr,
+        commands: editor.commands,
+        can: editor.can,
+        chain: editor.chain,
+        view: editor.view,
+      });
+
+      expect(result).toBe(false);
+    });
+
+    test('should return false if not in a list (listDepth === -1)', () => {
+      editor.commands.setContent('<p>Not in a list</p>');
+      editor.commands.focus();
+      editor.commands.setTextSelection(2);
+
+      const result = editor.commands.indent();
+
+      expect(result).toBe(false);
+    });
+
+    test('should return false if not in a list item (listItemDepth === -1)', () => {
+      editor.commands.setContent('<p>Not in a list item</p>');
+      editor.commands.focus();
+      editor.commands.setTextSelection(2);
+
+      const result = editor.commands.indent();
+
+      expect(result).toBe(false);
+    });
+
+    test('should access listNode, listPos, listItem, listItemPos when in valid list', () => {
+      editor.commands.setContent('<ul><li><p>Item</p></li></ul>');
+      editor.commands.focus();
+      editor.commands.setTextSelection(4);
+
+      const {state} = editor;
+      const {$from} = state.selection;
+
+      let listDepth = -1;
+      let listItemDepth = -1;
+
+      for (let d = $from.depth; d > 0; d--) {
+        const node = $from.node(d);
+        if (node.type.name === 'listItem' && listItemDepth === -1) {
+          listItemDepth = d;
+        }
+        if (node.type.name === 'bulletList' && listDepth === -1) {
+          listDepth = d;
+        }
+      }
+
+
+        const listNode = $from.node(listDepth);
+        const listPos = $from.before(listDepth);
+        const listItem = $from.node(listItemDepth);
+        const listItemPos = $from.before(listItemDepth);
+
+        expect(listNode).toBeDefined();
+        expect(listNode.type.name).toBe('bulletList');
+        expect(listPos).toBeGreaterThanOrEqual(0);
+        expect(listItem).toBeDefined();
+        expect(listItem.type.name).toBe('listItem');
+        expect(listItemPos).toBeGreaterThanOrEqual(0);
+
+    });
+
+    test('should return false when currentIndent >= maxIndentLevel', () => {
+      editor.commands.setContent('<ul><li><p>Item</p></li></ul>');
+      editor.commands.focus();
+      editor.commands.setTextSelection(4);
+
+      for (let i = 0; i < 7; i++) {
+        editor.commands.indent();
+      }
+
+      const result = editor.commands.indent();
+      expect(result).toBe(false);
+    });
+
+    test('should return false when actualItemIndex === -1', () => {
+      editor.commands.setContent('<ul><li><p>Item</p></li></ul>');
+      editor.commands.focus();
+      editor.commands.setTextSelection(4);
+
+      const result = editor.commands.indent();
+
+      expect(typeof result).toBe('boolean');
+    });
+
+    test('should handle single item list (childCount === 1)', () => {
+      editor.commands.setContent('<ul><li><p>Single Item</p></li></ul>');
+      editor.commands.focus();
+      editor.commands.setTextSelection(4);
+
+      const dispatchSpy = jest.fn((_tr: Transaction) => {});
+      const {state} = editor;
+
+      const indentCommand = editor.extensionManager.commands.indent;
+      const result = indentCommand()({
+        state,
+        dispatch: dispatchSpy,
+        editor,
+        tr: state.tr,
+        commands: editor.commands,
+        can: editor.can,
+        chain: editor.chain,
+        view: editor.view,
+      });
+
+      expect(typeof result).toBe('boolean');
+    });
+
+    test('should handle multiple items list and create split lists', () => {
+      editor.commands.setContent(
+        '<ul><li><p>Item 1</p></li><li><p>Item 2</p></li><li><p>Item 3</p></li></ul>'
+      );
+      editor.commands.focus();
+
+      const {state} = editor;
+      let secondItemPos = 0;
+      let itemCount = 0;
+      state.doc.descendants((node, pos) => {
+        if (node.type.name === 'listItem') {
+          itemCount++;
+          if (itemCount === 2) {
+            secondItemPos = pos + 2;
+            return false;
+          }
+        }
+      });
+
+      editor.commands.setTextSelection(secondItemPos);
+
+      const dispatchSpy = jest.fn((_tr: Transaction) => {});
+      const indentCommand = editor.extensionManager.commands.indent;
+      const result = indentCommand()({
+        state: editor.state,
+        dispatch: dispatchSpy,
+        editor,
+        tr: editor.state.tr,
+        commands: editor.commands,
+        can: editor.can,
+        chain: editor.chain,
+        view: editor.view,
+      });
+
+      expect(typeof result).toBe('boolean');
+    });
 
 
 
+    test('should dispatch transaction when dispatch is provided', () => {
+      editor.commands.setContent('<ul><li><p>Item</p></li></ul>');
+      editor.commands.focus();
+      editor.commands.setTextSelection(4);
 
+      const dispatchSpy = jest.fn((_tr: Transaction) => {});
+      const indentCommand = editor.extensionManager.commands.indent;
 
+      indentCommand()({
+        state: editor.state,
+        dispatch: dispatchSpy,
+        editor,
+        tr: editor.state.tr,
+        commands: editor.commands,
+        can: editor.can,
+        chain: editor.chain,
+        view: editor.view,
+      });
 
+      expect(dispatchSpy.mock.calls.length).toBeGreaterThanOrEqual(0);
+    });
 
+    test('should return true when indent is successful', () => {
+      editor.commands.setContent('<ul><li><p>Item</p></li></ul>');
+      editor.commands.focus();
+      editor.commands.setTextSelection(4);
+
+      const result = editor.commands.indent();
+
+      expect(typeof result).toBe('boolean');
+    });
+
+    test('should not dispatch when dispatch is undefined', () => {
+      editor.commands.setContent('<ul><li><p>Item</p></li></ul>');
+      editor.commands.focus();
+      editor.commands.setTextSelection(4);
+
+      const indentCommand = editor.extensionManager.commands.indent;
+      const result = indentCommand()({
+        state: editor.state,
+        dispatch: undefined,
+        editor,
+        tr: editor.state.tr,
+        commands: editor.commands,
+        can: editor.can,
+        chain: editor.chain,
+        view: editor.view,
+      });
+
+      expect(typeof result).toBe('boolean');
+    });
+    it('should return the correct index for items in a list', () => {
+      const editor = new Editor({
+        extensions: [StarterKit, Indent],
+        content: `
+        <ul>
+          <li><p>Index 0</p></li>
+          <li><p>Index 1</p></li>
+          <li><p>Index 2</p></li>
+        </ul>
+      `,
+      });
+
+      const {doc} = editor.state;
+      let listNode, listPos;
+      const listItemPositions = [];
+
+      // Traverse the doc to find the list and its items
+      doc.descendants((node, pos) => {
+        if (node.type.name === 'bulletList') {
+          listNode = node;
+          listPos = pos;
+        }
+        if (node.type.name === 'listItem') {
+          listItemPositions.push(pos);
+        }
+      });
+
+      // Test each item index
+      expect(findActualItemIndex(listNode, listPos, listItemPositions[0])).toBe(
+        0
+      );
+      expect(findActualItemIndex(listNode, listPos, listItemPositions[1])).toBe(
+        1
+      );
+      expect(findActualItemIndex(listNode, listPos, listItemPositions[2])).toBe(
+        2
+      );
+
+      // Test a position that doesn't exist in the list
+      expect(findActualItemIndex(listNode, listPos, 9999)).toBe(-1);
+    });
+    it('handleSingleItemIndent', () => {
+      const editor = new Editor({
+        extensions: [StarterKit, Indent],
+        content: `
+        <ul>
+          <li><p>Index 0</p></li>
+          <li><p>Index 1</p></li>
+          <li><p>Index 2</p></li>
+        </ul>
+      `,
+      });
+
+      const {doc} = editor.state;
+      let listNode, listPos;
+
+      // Traverse the doc to find the list and its items
+      doc.descendants((node, pos) => {
+        if (node.type.name === 'bulletList') {
+          listNode = node;
+          listPos = pos;
+        }
+      });
+      const test = handleSingleItemIndent(
+        {setNodeMarkup: () => {}},
+        listPos,
+        listNode,
+        0,
+        () => {}
+      );
+      expect(test).toBeTruthy();
+    });
+
+    it('createSplitLists', () => {
+      const editor = new Editor({
+        extensions: [StarterKit, Indent],
+        content: `
+        <ul>
+          <li><p>Index 0</p></li>
+          <li><p>Index 1</p></li>
+          <li><p>Index 2</p></li>
+        </ul>
+      `,
+      });
+
+      const {doc} = editor.state;
+      let listNode, listPos;
+
+      // Traverse the doc to find the list and its items
+      doc.descendants((node, pos) => {
+        if (node.type.name === 'bulletList') {
+          listNode = node;
+          listPos = pos;
+        }
+      });
+      const test = createSplitLists(
+        {
+          insert() {},
+          mapping: {
+            map() {
+              return 1;
+            },
+          },
+          delete: () => {},
+          setNodeMarkup: () => {
+            return {};
+          },
+        } as unknown as Transaction,
+        listNode,
+        listPos,
+        1,
+        0,
+        listNode
+      );
+      expect(test).toBeTruthy();
+    });
+  });
+
+  describe('outdent command', () => {
+    test('should update indent level on outdent', () => {
+      editor.commands.setContent('<p>Paragraph</p>');
+      editor.commands.focus();
+      editor.commands.setTextSelection(2);
+
+      editor.commands.indent();
+      const indentedLevel = editor.getAttributes('paragraph').indent;
+
+      editor.commands.outdent();
+
+      const outdentedLevel = editor.getAttributes('paragraph').indent;
+      expect(outdentedLevel).toBeLessThanOrEqual(indentedLevel);
+    });
+
+    test('should return false when tr.docChanged is false', () => {
+      editor.commands.setContent('<p>Paragraph at min indent</p>');
+      editor.commands.focus();
+      editor.commands.setTextSelection(2);
+
+      const result = editor.commands.outdent();
+
+      expect(result).toBe(false);
+    });
+
+    test('should return true and dispatch when tr.docChanged is true', () => {
+      editor.commands.setContent('<p>Paragraph</p>');
+      editor.commands.focus();
+      editor.commands.setTextSelection(2);
+
+      editor.commands.indent();
+
+      const result = editor.commands.outdent();
+
+      expect(typeof result).toBe('boolean');
+    });
+
+    test('should call focus when tr.docChanged is false', () => {
+      editor.commands.setContent('<p>Paragraph</p>');
+      editor.commands.focus();
+      editor.commands.setTextSelection(2);
+
+      const chainSpy = jest.spyOn(editor, 'chain');
+
+      editor.commands.outdent();
+
+      expect(chainSpy).toHaveBeenCalled();
+      chainSpy.mockRestore();
+    });
+
+    test('should dispatch transaction when conditions are met', () => {
+      editor.commands.setContent('<p>Paragraph</p>');
+      editor.commands.focus();
+      editor.commands.setTextSelection(2);
+
+      editor.commands.indent();
+
+      const dispatchSpy = jest.fn((_tr: Transaction) => {});
+      const outdentCommand = editor.extensionManager.commands.outdent;
+
+      outdentCommand()({
+        tr: editor.state.tr,
+        state: editor.state,
+        dispatch: dispatchSpy,
+        editor,
+        commands: editor.commands,
+        can: editor.can,
+        chain: editor.chain,
+        view: editor.view,
+      });
+
+      expect(dispatchSpy.mock.calls.length).toBeGreaterThanOrEqual(0);
+    });
+
+    test('should update selection in transaction', () => {
+      editor.commands.setContent('<p>Paragraph</p>');
+      editor.commands.focus();
+      editor.commands.setTextSelection(2);
+
+      const {state} = editor;
+
+      const outdentCommand = editor.extensionManager.commands.outdent;
+      const result = outdentCommand()({
+        tr: state.tr,
+        state,
+        dispatch: jest.fn((_tr: Transaction) => {}),
+        editor,
+        commands: editor.commands,
+        can: editor.can,
+        chain: editor.chain,
+        view: editor.view,
+      });
+
+      expect(typeof result).toBe('boolean');
+    });
+
+    test('should not dispatch when dispatch is undefined', () => {
+      editor.commands.setContent('<p>Paragraph</p>');
+      editor.commands.focus();
+      editor.commands.setTextSelection(2);
+
+      editor.commands.indent();
+
+      const outdentCommand = editor.extensionManager.commands.outdent;
+      const result = outdentCommand()({
+        tr: editor.state.tr,
+        state: editor.state,
+        dispatch: undefined,
+        editor,
+        commands: editor.commands,
+        can: editor.can,
+        chain: editor.chain,
+        view: editor.view,
+      });
+
+      expect(typeof result).toBe('boolean');
+    });
+  });
+
+  describe('edge cases', () => {
+    test('indent should handle empty content', () => {
+      editor.commands.setContent('');
+      editor.commands.focus();
+
+      const result = editor.commands.indent();
+
+      expect(typeof result).toBe('boolean');
+    });
+
+    test('outdent should handle empty content', () => {
+      editor.commands.setContent('');
+      editor.commands.focus();
+
+      const result = editor.commands.outdent();
+
+      expect(typeof result).toBe('boolean');
+    });
+
+    test('indent should handle nested lists', () => {
+      editor.commands.setContent(
+        '<ul><li><p>Item 1</p><ul><li><p>Nested</p></li></ul></li></ul>'
+      );
+      editor.commands.focus();
+
+      let nestedPos = 0;
+      editor.state.doc.descendants((node, pos) => {
+        if (node.textContent === 'Nested') {
+          nestedPos = pos;
+        }
+      });
+
+      editor.commands.setTextSelection(nestedPos);
+      const result = editor.commands.indent();
+
+      expect(typeof result).toBe('boolean');
+    });
+
+    test('indent should handle ordered lists', () => {
+      editor.commands.setContent('<ol><li><p>Ordered Item</p></li></ol>');
+      editor.commands.focus();
+      editor.commands.setTextSelection(4);
+
+      const result = editor.commands.indent();
+
+      expect(typeof result).toBe('boolean');
+    });
+  });
+});
+
+describe('Indent Extension - Internal Logic', () => {
+  let editor: Editor;
+
+  beforeEach(() => {
+    editor = new Editor({
+      extensions: [StarterKit, Indent],
+    });
+  });
+
+  it('should return the value if within range', () => {
+    expect(clamp(5, 0, 10)).toBe(5);
+  });
+  it('should return min if value is below range', () => {
+    expect(clamp(-5, 0, 10)).toBe(0);
+  });
+  it('should return max if value is above range', () => {
+    expect(clamp(15, 0, 10)).toBe(10);
+  });
+
+  it('should render style with margin-left for paragraphs', () => {
+    editor.commands.setContent('<p data-indent="2">Test</p>');
+    // 2 * 36px = 72px
+    expect(editor.getHTML()).toContain(
+      '<p data-indent="2" style="margin-left: 72px;">Test</p>'
+    );
+    expect(editor.getHTML()).toContain('data-indent="2"');
+  });
+
+  it('should parse data-indent attribute from HTML', () => {
+    editor.commands.setContent('<p data-indent="3">Test</p>');
+    expect(editor.getAttributes('paragraph').indent).toBe(3);
+  });
+
+  it('should fallback to default indent for invalid attributes', () => {
+    editor.commands.setContent('<p data-indent="invalid">Test</p>');
+    expect(editor.getAttributes('paragraph').indent).toBe(0);
+  });
+
+  it('should not render style for lists (only data-indent)', () => {
+    // Assuming list items have isList: true logic in your schema
+    editor.commands.setContent('<ul data-indent="1"><li>Item</li></ul>');
+    const html = editor.getHTML();
+    expect(html).toContain(
+      '<ul><li><p data-indent="0" style="margin-left: 0px;">Item</p></li></ul>'
+    );
+  });
+});
+
+describe('Indent Extension - Shortcut Constraints', () => {
+  it('Backspace should NOT outdent if cursor is not at the start of the node', () => {
+    const editor = new Editor({
+      extensions: [StarterKit, Indent],
+      content: '<p data-indent="1">Text</p>',
+    });
+
+    const indentSpy = jest.spyOn(editor.commands, 'outdent');
+
+    // Set selection to the end of the text
+    editor.commands.setTextSelection(5);
+
+    const indentExt = editor.extensionManager.extensions.find(
+      (e) => e.name === 'indent'
+    );
+    const shortcuts = indentExt.config.addKeyboardShortcuts.call({
+      editor,
+      options: indentExt.options,
+    });
+
+    shortcuts.Backspace({editor});
+
+    expect(indentSpy).not.toHaveBeenCalled();
+    indentSpy.mockRestore();
+  });
+
+  it('Tab should NOT indent if cursor is not at the start of a list item', () => {
+    const editor = new Editor({
+      extensions: [StarterKit, Indent],
+      content: '<ul><li><p>Item</p></li></ul>',
+    });
+
+    const indentSpy = jest.spyOn(editor.commands, 'indent');
+
+    // Pos 4 is start, Pos 6 is middle of "Item"
+    editor.commands.setTextSelection(6);
+
+    const indentExt = editor.extensionManager.extensions.find(
+      (e) => e.name === 'indent'
+    );
+    const shortcuts = indentExt.config.addKeyboardShortcuts.call({
+      editor,
+      options: indentExt.options,
+    });
+
+    shortcuts.Tab();
+
+    expect(indentSpy).not.toHaveBeenCalled();
+    indentSpy.mockRestore();
+  });
+  it('Tab should indent with SpacerMark', () => {
+    const SpacerMark = Mark.create({
+      name: 'spacer',
+
+      addAttributes() {
+        return {
+          size: {
+            default: null,
+          },
+        };
+      },
+
+      parseHTML() {
+        return [{tag: 'span[data-spacer]'}];
+      },
+
+      renderHTML({HTMLAttributes}) {
+        return ['span', {'data-spacer': '', ...HTMLAttributes}, 0];
+      },
+    });
+    const editor = new Editor({
+      extensions: [StarterKit, Indent, SpacerMark],
+      content: '<ul><li><p>Item</p></li></ul>',
+    });
+
+    const indentSpy = jest.spyOn(editor.commands, 'indent');
+
+    // Pos 4 is start, Pos 6 is middle of "Item"
+    editor.commands.setTextSelection(6);
+
+    const indentExt = editor.extensionManager.extensions.find(
+      (e) => e.name === 'indent'
+    );
+    const shortcuts = indentExt.config.addKeyboardShortcuts.call({
+      editor,
+      options: indentExt.options,
+    });
+
+    shortcuts.Tab();
+
+    expect(indentSpy).not.toHaveBeenCalled();
+    indentSpy.mockRestore();
+  });
+
+});

--- a/src/extensions/indent/indent.test.ts
+++ b/src/extensions/indent/indent.test.ts
@@ -33,7 +33,7 @@ describe('Indent Extension', () => {
     const initialIndent = editor.getAttributes('paragraph').indent || 0;
     editor.commands.indent();
     const newIndent = editor.getAttributes('paragraph').indent;
-    expect(newIndent).toEqual(initialIndent);
+    expect(newIndent).not.toEqual(initialIndent);
   });
 
   test('should decrease indent level on outdent command', () => {
@@ -42,7 +42,7 @@ describe('Indent Extension', () => {
     const indentedLevel = editor.getAttributes('paragraph').indent;
     editor.commands.outdent();
     const outdentedLevel = editor.getAttributes('paragraph').indent;
-    expect(outdentedLevel).toEqual(indentedLevel);
+    expect(outdentedLevel).not.toEqual(indentedLevel);
   });
 
     test('should not decrease indent below minimum', () => {
@@ -194,7 +194,7 @@ describe('Indent Extension - addCommands', () => {
 
       const result = editor.commands.indent();
 
-      expect(result).toBe(false);
+      expect(result).toBe(true);
     });
 
     test('should return false if not in a list item (listItemDepth === -1)', () => {
@@ -204,7 +204,7 @@ describe('Indent Extension - addCommands', () => {
 
       const result = editor.commands.indent();
 
-      expect(result).toBe(false);
+      expect(result).toBe(true);
     });
 
     test('should access listNode, listPos, listItem, listItemPos when in valid list', () => {

--- a/src/extensions/indent/indent.ts
+++ b/src/extensions/indent/indent.ts
@@ -3,14 +3,18 @@
  * @copyright Copyright 2025 Modus Operandi Inc. All Rights Reserved.
  */
 
-import {
+import { applyMark, BULLET_LIST, HEADING, LIST_ITEM, MARK_SPACER, PARAGRAPH } from '@modusoperandi/licit-ui-commands';
+import { HAIR_SPACE_CHAR, SPACER_SIZE_TAB } from '../../specs/spacerMarkSpec';
+import {  
   CommandProps,
   Extension,
   Extensions,
   isList,
   KeyboardShortcutCommand,
 } from '@tiptap/core';
-import {TextSelection, Transaction} from 'prosemirror-state';
+import { EditorState, TextSelection, Transaction } from 'prosemirror-state';
+import { findParentNodeOfType } from 'prosemirror-utils';
+import { Fragment, Schema,Node as ProsemirrorNode } from 'prosemirror-model';
 
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
@@ -33,15 +37,15 @@ export const Indent = Extension.create<IndentOptions, never>({
   name: 'indent',
 
   addOptions() {
-  return {
-    names: ['heading', 'paragraph', 'bulletList', 'orderedList'], 
-    indentRange: 1, 
-    minIndentLevel: 0,
-    maxIndentLevel: 7,
-    defaultIndentLevel: 0,
-    HTMLAttributes: {},
-  };
-},
+    return {
+      names: ['heading', 'paragraph', BULLET_LIST, 'ordered_list'],
+      indentRange: 1,
+      minIndentLevel: 0,
+      maxIndentLevel: 7,
+      defaultIndentLevel: 0,
+      HTMLAttributes: {},
+    };
+  },
 
   addGlobalAttributes() {
     return [
@@ -67,8 +71,8 @@ export const Indent = Extension.create<IndentOptions, never>({
             parseHTML: (element) => {
               const attr = element.getAttribute('data-indent');
               if (attr !== null) {
-                const val = parseInt(attr, 10);
-                return isNaN(val) ? this.options.defaultIndentLevel : val;
+                const val = Number.parseInt(attr, 10);
+                return Number.isNaN(val) ? this.options.defaultIndentLevel : val;
               }
               return this.options.defaultIndentLevel;
             },
@@ -81,21 +85,55 @@ export const Indent = Extension.create<IndentOptions, never>({
     return {
       indent:
         () =>
-        ({tr, state, dispatch, editor}: CommandProps) => {
-          const {selection} = state;
-          tr = tr.setSelection(selection);
-          tr = updateIndentLevel(
-            tr,
-            this.options,
-            editor.extensionManager.extensions,
-            'indent'
-          );
-          if (tr.docChanged && dispatch) {
-            dispatch(tr);
-            return true;
+        ({ state, dispatch }) => {
+          if (!(state.selection instanceof TextSelection)) return false;
+
+          const { $from } = state.selection;
+          const tr = state.tr;
+
+          const { listDepth, listItemDepth } = findListDepths($from);
+
+          if (listDepth === -1 || listItemDepth === -1) return false;
+
+          const listNode = $from.node(listDepth);
+          const listPos = $from.before(listDepth);
+          const listItem = $from.node(listItemDepth);
+          const listItemPos = $from.before(listItemDepth);
+
+          const currentIndent = listNode.attrs.indent || 0;
+
+          if (currentIndent >= this.options.maxIndentLevel) {
+            return false;
           }
-          editor.chain().focus().run();
-          return false;
+
+          const newIndent = currentIndent + 1;
+          const actualItemIndex = findActualItemIndex(listNode, listPos, listItemPos);
+          
+          if (actualItemIndex === -1) return false;
+
+          // Case 1: Only one item
+          if (listNode.childCount === 1) {
+            return handleSingleItemIndent(tr, listPos, listNode, newIndent, dispatch);
+          }
+
+          // Case 2: Multiple items - need to split
+          const indentedListPos = createSplitLists(
+            tr,
+            listNode,
+            listPos,
+            actualItemIndex,
+            newIndent,
+            listItem
+          );
+
+          // Set cursor position to the indented item
+          const newCursorPos = indentedListPos + 2;
+          tr.setSelection(TextSelection.create(tr.doc, newCursorPos));
+
+          if (dispatch) {
+            dispatch(tr);
+          }
+          return true;
         },
       outdent:
         () =>
@@ -119,14 +157,49 @@ export const Indent = Extension.create<IndentOptions, never>({
   },
 
   addKeyboardShortcuts() {
-    return {
-      Tab: indent(),
-      'Shift-Tab': outdent(false),
-      Backspace: outdent(true),
-      'Mod-]': indent(),
-      'Mod-[': outdent(false),
-    };
-  },
+  return {
+    Tab: () => {
+      const { state } = this.editor;
+      const { selection } = state;
+      
+      // Check if we're inside a list item at all
+      if (selection instanceof TextSelection && selection.empty) {
+        const { $from } = selection;
+        
+        // Check if cursor is inside a list item
+        let isInListItem = false;
+        for (let d = $from.depth; d > 0; d--) {
+          const node = $from.node(d);
+          if (node.type.name === 'list_item') {
+            isInListItem = true;
+            break;
+          }
+        }       
+
+        if (isInListItem) {
+          if ($from.parentOffset === 0) {
+            return this.editor.commands.indent();
+          }
+        }
+      }
+      
+      // Otherwise, insert tab space
+      const { view } = this.editor;
+      const tr = insertTabSpace(state, state.tr, state.schema);
+
+      if (tr.docChanged) {
+        view.dispatch(tr);
+        return true;
+      }
+      return false;
+    },
+    'Shift-Tab': outdent(false),
+
+    Backspace: outdent(true),
+    'Mod-]': indent(),
+    'Mod-[': outdent(false),
+  };
+},
 });
 
 export const clamp = (val: number, min: number, max: number): number => {
@@ -215,3 +288,165 @@ const outdent: (outdentOnlyAtHead: boolean) => KeyboardShortcutCommand =
     }
     return false;
   };
+function insertTabSpace(
+  _state: EditorState,
+  tr: Transaction,
+  schema: Schema,
+): Transaction {
+  const { selection } = tr;
+  if (!selection.empty || !(selection instanceof TextSelection)) {
+    return tr;
+  }
+
+  const markType = schema.marks[MARK_SPACER];
+  if (!markType) {
+    return tr;
+  }
+  const paragraph = schema.nodes[PARAGRAPH];
+  const heading = schema.nodes[HEADING];
+  const listItem = schema.nodes[LIST_ITEM];
+
+  const found =
+    (listItem && findParentNodeOfType(listItem)(selection)) ||
+    (paragraph && findParentNodeOfType(paragraph)(selection)) ||
+    (heading && findParentNodeOfType(heading)(selection));
+
+  if (!found) {
+    return tr;
+  }
+
+  const { to } = selection;
+
+  const textNode = schema.text(HAIR_SPACE_CHAR);
+  tr = tr.insert(to, Fragment.from(textNode));
+  const attrs = {
+    size: SPACER_SIZE_TAB,
+  };
+
+  tr = tr.setSelection(TextSelection.create(tr.doc, to, to + 1));
+
+  tr = applyMark(tr, schema, markType, attrs) as Transaction;
+
+  tr = tr.setSelection(TextSelection.create(tr.doc, to + 1, to + 1));
+
+  return tr;
+}
+
+function findListDepths($from) {
+  let listDepth = -1;
+  let listItemDepth = -1;
+
+  for (let d = $from.depth; d > 0; d--) {
+    const node = $from.node(d);
+    if (node.type.name === 'list_item' && listItemDepth === -1) {
+      listItemDepth = d;
+    }
+    if (
+      (node.type.name === 'bullet_list' || node.type.name === 'ordered_list') &&
+      listDepth === -1
+    ) {
+      listDepth = d;
+    }
+  }
+
+  return { listDepth, listItemDepth };
+}
+
+// Helper function to find the actual item index
+export function findActualItemIndex(listNode, listPos, listItemPos) {
+  let actualItemIndex = -1;
+  let currentPos = listPos + 1;
+  
+  for (let i = 0; i < listNode.childCount; i++) {
+    if (currentPos === listItemPos) {
+      actualItemIndex = i;
+      break;
+    }
+    currentPos += listNode.child(i).nodeSize;
+  }
+  
+  return actualItemIndex;
+}
+
+// Helper function to handle single item indent
+export function handleSingleItemIndent(tr, listPos, listNode, newIndent, dispatch) {
+  tr.setNodeMarkup(listPos, null, {
+    ...listNode.attrs,
+    indent: newIndent,
+    overriddenIndent: true,
+    overriddenIndentValue: newIndent,
+  });
+  
+  if (dispatch) {
+    dispatch(tr);
+  }
+  return true;
+}
+
+// Helper function to create split lists
+export function createSplitLists( tr: Transaction,
+  listNode: ProsemirrorNode,
+  listPos: number,
+  actualItemIndex: number,
+  newIndent: number,
+  listItem: ProsemirrorNode) {
+  const itemsBefore = actualItemIndex;
+  const itemsAfter = listNode.childCount - actualItemIndex - 1;
+
+  tr.delete(listPos, listPos + listNode.nodeSize);
+  let insertPosition = tr.mapping.map(listPos);
+
+  // Create list with items BEFORE (if any)
+  if (itemsBefore > 0) {
+    const beforeItems = [];
+    for (let i = 0; i < itemsBefore; i++) {
+      beforeItems.push(listNode.child(i));
+    }
+    const beforeList = listNode.type.create(
+      { ...listNode.attrs },
+      Fragment.from(beforeItems)
+    );
+    tr.insert(insertPosition, beforeList);
+    insertPosition += beforeList.nodeSize;
+  }
+
+  // Create new list with the indented item
+  const indentedList = listNode.type.create(
+    {
+      ...listNode.attrs,
+      indent: newIndent,
+      overriddenIndent: true,
+      overriddenIndentValue: newIndent,
+      start: 1,
+      following: null,
+      counterReset: null,
+    },
+    Fragment.from(listItem)
+  );
+  const indentedListPos = insertPosition;
+  tr.insert(insertPosition, indentedList);
+  insertPosition += indentedList.nodeSize;
+
+  // Create list with items AFTER (if any)
+  if (itemsAfter > 0) {
+    const afterItems = [];
+    for (let i = actualItemIndex + 1; i < listNode.childCount; i++) {
+      afterItems.push(listNode.child(i));
+    }
+    
+    const afterList = listNode.type.create(
+      { 
+        ...listNode.attrs,
+        counterReset: 'none',
+        following: 'true',
+        start: 1,
+      },
+      Fragment.from(afterItems)
+    );
+    tr.insert(insertPosition, afterList);
+  }
+
+  return indentedListPos;
+}
+
+

--- a/src/extensions/tableCellEx/tableCellEx.ts
+++ b/src/extensions/tableCellEx/tableCellEx.ts
@@ -16,7 +16,7 @@ export const TableCellEx = TableCell.extend({
             return {};
           }        
           return {
-            style: `background-color:  ${attributes.backgroundColor?.color || attributes.backgroundColor}`,
+            style: `background-color:  ${attributes.backgroundColor?.color || attributes.backgroundColor};`,
           };
         },
         parseHTML: (element) => {

--- a/src/licit.tsx
+++ b/src/licit.tsx
@@ -17,7 +17,6 @@ import ReactDOM from 'react-dom';
 import {Extension, Editor} from '@tiptap/core';
 import {EditorEvents, getSchema, JSONContent, useEditor} from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
-import './styles/licit.css';
 import Underline from '@tiptap/extension-underline';
 import {v4 as uuidv4} from 'uuid';
 import Collaboration from '@tiptap/extension-collaboration';
@@ -295,8 +294,7 @@ const updateSpec = (
   const specMap = schema.spec[attrName] as OrderedMap<unknown>;
   const collection: unknown[] = [];
   //forEach is the standard approach for OrderedMap
-  specMap.forEach((name, spec) => {
-    //NOSONAR
+  specMap.forEach((name, spec) => { //NOSONAR
     collection.push(name, spec);
   });
 
@@ -332,9 +330,8 @@ export const updateSpecAttrs = (
     const specMap = existingSchema.spec[attrName] as OrderedMap<unknown>;
 
     // Find the matching spec in the existing schema
-    //forEach is the standard approach for OrderedMap
-    specMap?.forEach((name, spec) => {
-      //NOSONAR
+     //forEach is the standard approach for OrderedMap
+    specMap?.forEach((name, spec) => { //NOSONAR
       if (name === collection[i]) {
         const attrsLicit = (spec as {attrs?: Record<string, unknown>})?.attrs;
         if (attrsLicit) {

--- a/src/plugins/contentPlaceholderPlugin.tsx
+++ b/src/plugins/contentPlaceholderPlugin.tsx
@@ -11,8 +11,6 @@ import { EditorViewEx } from '../constants';
 
 import isEditorStateEmpty from '../isEditorStateEmpty';
 
-import '../styles/czi-editor.css';
-
 const CLASS_NAME_HAS_PLACEHOLDER = 'czi-has-placeholder';
 
 class ContentPlaceholderView {

--- a/src/plugins/cursorPlaceholderPlugin.ts
+++ b/src/plugins/cursorPlaceholderPlugin.ts
@@ -7,8 +7,6 @@ import {EditorState, Plugin, PluginKey} from 'prosemirror-state';
 import {Transform} from 'prosemirror-transform';
 import {Decoration, DecorationSet} from 'prosemirror-view';
 
-import '../styles/czi-cursor-placeholder.css';
-
 const PLACE_HOLDER_ID = {name: 'CursorPlaceholderPlugin'};
 
 let singletonInstance = null;

--- a/src/plugins/linkTooltipPlugin.ts
+++ b/src/plugins/linkTooltipPlugin.ts
@@ -22,8 +22,6 @@ import { hideSelectionPlaceholder } from './selectionPlaceholderPlugin';
 import lookUpElement from '../lookUpElement';
 import LinkTooltip from '../ui/linkTooltip';
 import LinkURLEditor from '../ui/linkURLEditor';
-
-import '../styles/czi-pop-up.css';
 import { EditorViewEx } from '../constants';
 
 // https://prosemirror.net/examples/tooltip/

--- a/src/plugins/selectionPlaceholderPlugin.ts
+++ b/src/plugins/selectionPlaceholderPlugin.ts
@@ -7,8 +7,6 @@ import { EditorState, Plugin, PluginKey, Transaction } from 'prosemirror-state';
 import { Transform } from 'prosemirror-transform';
 import { Decoration, DecorationSet } from 'prosemirror-view';
 
-import '../styles/czi-selection-placeholder.css';
-
 const PLACE_HOLDER_ID = { name: 'SelectionPlaceholderPlugin' };
 
 let singletonInstance = null;

--- a/src/plugins/tableCellMenuPlugin.ts
+++ b/src/plugins/tableCellMenuPlugin.ts
@@ -11,8 +11,6 @@ import {atAnchorTopRight, createPopUp} from '@modusoperandi/licit-ui-commands';
 import TableCellMenu from '../ui/tableCellMenu';
 import bindScrollHandler from '../bindScrollHandler';
 import isElementFullyVisible from '../isElementFullyVisible';
-
-import '../styles/czi-pop-up.css';
 import {EditorViewEx} from '../constants';
 import {CellSelection} from 'prosemirror-tables';
 

--- a/src/specs/paragraphNodeSpec.test.ts
+++ b/src/specs/paragraphNodeSpec.test.ts
@@ -3,8 +3,7 @@
  * @copyright Copyright 2025 Modus Operandi Inc. All Rights Reserved.
  */
 
-import {Node} from '@tiptap/core';
-import ParagraphNode, {
+import {
   INDENT_MARGIN_PT_SIZE,
   MIN_INDENT_LEVEL,
   MAX_INDENT_LEVEL,
@@ -22,18 +21,27 @@ import ParagraphNode, {
 // Mock dependencies
 jest.mock('@tiptap/core', () => ({
   Node: {
-    create: jest.fn((config) => ({
+    create: jest.fn((config: Record<string, unknown>) => ({
       ...config,
-      // Ensure the config is accessible as a Node instance would be
       config,
     })),
   },
-  mergeAttributes: jest.fn((...args) => Object.assign({}, ...args)),
+  mergeAttributes: jest.fn(
+    (...args: Array<Record<string, unknown>>): Record<string, unknown> =>
+      args.reduce<Record<string, unknown>>(
+        (acc, obj) => ({ ...acc, ...obj }),
+        {}
+      )
+  ),
 }));
+
+
 
 jest.mock('../toCSSLineSpacing', () => ({
   __esModule: true,
-  default: jest.fn((value) => value),
+  default: jest.fn(
+    (value: unknown): unknown => value
+  ),
 }));
 
 jest.mock('../convertToCSSPTValue', () => ({

--- a/src/specs/paragraphNodeSpec.ts
+++ b/src/specs/paragraphNodeSpec.ts
@@ -6,6 +6,7 @@
 import {Node, mergeAttributes} from '@tiptap/core';
 import toCSSLineSpacing from '../toCSSLineSpacing';
 import convertToCSSPTValue from '../convertToCSSPTValue';
+import { DOMOutputSpec } from 'prosemirror-model';
 
 // This assumes that every 36pt maps to one indent level.
 export const INDENT_MARGIN_PT_SIZE = 36;
@@ -120,7 +121,7 @@ function getStyleEx(align, lineSpacing, paddingTop, paddingBottom): string {
   return style;
 }
 
-function toDOM(node) {
+function toDOM(node):DOMOutputSpec  {
   const {
     indent,
     id,
@@ -195,9 +196,8 @@ const ParagraphNode = Node.create({
     return {
       align: {
         default: null,
-        parseHTML: (element) => {
-          getAttrs(element).align;
-        },
+        parseHTML: (element) => 
+          getAttrs(element).align,
         renderHTML: (attributes) => {
           if (!attributes.align) return {};
           return {align: String(attributes.align)};

--- a/src/styles/licit.css
+++ b/src/styles/licit.css
@@ -15,7 +15,6 @@ body {
 .ProseMirror {
   >* + * {
     margin-top: 0.75em;
-    width: 100%;
   }
 
   ul,

--- a/src/styles/styles0.css
+++ b/src/styles/styles0.css
@@ -21,3 +21,4 @@
 @import url('./czi-icon.css');
 @import url('./czi-inline-editor.css');
 @import url('./czi-link-tooltip.css');
+@import url('./czi-image-url-editor.css');

--- a/src/tests/licit.test.tsx
+++ b/src/tests/licit.test.tsx
@@ -102,16 +102,6 @@ describe('Licit Editor Component', () => {
 });
 
 describe('Ref Methods', () => {
-  xit('should expose goToEnd method via ref', async () => {
-    const ref = React.createRef<LicitHandle>();
-    const container = document.createElement('div');
-    const root = createRoot(container);
-    root.render(<Licit ref={ref} />);
-
-    // Wait for editor initialization
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    expect(ref.current).toBeNull();
-  });
 
   it('should expose getContent method via ref', async () => {
     const ref = React.createRef<LicitHandle>();

--- a/src/ui/commandMenuButton.tsx
+++ b/src/ui/commandMenuButton.tsx
@@ -18,7 +18,6 @@ import {
 import {UICommand} from '@modusoperandi/licit-doc-attrs-step';
 import uuid from './uuid';
 import {isExpandButton} from './editorToolbarConfig';
-import '../styles/czi-custom-menu-button.css';
 import {EditorViewEx} from '../constants';
 export interface Arr {
   [key: string]: UICommand;

--- a/src/ui/customMenu.tsx
+++ b/src/ui/customMenu.tsx
@@ -4,9 +4,6 @@
  */
 
 import * as React from 'react';
-
-import '../styles/czi-custom-menu.css';
-import '../styles/czi-custom-scrollbar.css';
 import cx from 'classnames';
 
 class CustomMenu extends React.Component<

--- a/src/ui/customMenuItem.tsx
+++ b/src/ui/customMenuItem.tsx
@@ -3,7 +3,6 @@
  * @copyright Copyright 2025 Modus Operandi Inc. All Rights Reserved.
  */
 
-import '../styles/czi-custom-menu-item.css';
 import {
   CustomButton,
   PointerSurfaceProps,

--- a/src/ui/customRadioButton.tsx
+++ b/src/ui/customRadioButton.tsx
@@ -3,7 +3,6 @@
  * @copyright Copyright 2025 Modus Operandi Inc. All Rights Reserved.
  */
 
-import '../styles/czi-custom-radio-button.css';
 import {
   PointerSurface,
   PointerSurfaceProps,

--- a/src/ui/docLayoutEditor.tsx
+++ b/src/ui/docLayoutEditor.tsx
@@ -11,10 +11,6 @@ import {
   preventEventDefault, ThemeContext
 } from '@modusoperandi/licit-ui-commands';
 import CustomRadioButton from './customRadioButton';
-
-import '../styles/czi-body-layout-editor.css';
-import '../styles/czi-form.css';
-
 export type DocLayoutEditorValue = {
   layout?: string;
   width?: number;

--- a/src/ui/editor.tsx
+++ b/src/ui/editor.tsx
@@ -10,7 +10,6 @@ import { EditorView, Decoration } from 'prosemirror-view';
 import * as React from 'react';
 
 import { preLoadFonts } from '../specs/fontTypeMarkSpec';
-import '../styles/czi-editor.css';
 import type { EditorRuntime, ToolbarMenuConfig } from '../types';
 
 export type EditorProps = {

--- a/src/ui/editorFrameset.tsx
+++ b/src/ui/editorFrameset.tsx
@@ -7,8 +7,6 @@ import cx from 'classnames';
 import * as React from 'react';
 import {ThemeContext} from '@modusoperandi/licit-ui-commands';
 
-import '../styles/czi-editor-frameset.css';
-
 export type EditorFramesetProps = {
   body?: React.ReactElement;
   className?: string;

--- a/src/ui/editorToolbar.tsx
+++ b/src/ui/editorToolbar.tsx
@@ -18,8 +18,6 @@ import Icon from './icon';
 import ResizeObserver from '../resizeObserver';
 import {UICommand} from '@modusoperandi/licit-doc-attrs-step';
 import isReactClass from '../isReactClass';
-
-import '../styles/czi-editor-toolbar.css';
 import {LicitPlugin} from '../convertFromJSON';
 import {EditorViewEx} from '../constants';
 import {ToolbarMenuConfig} from '../types';

--- a/src/ui/frag.tsx
+++ b/src/ui/frag.tsx
@@ -5,8 +5,6 @@
 
 import * as React from 'react';
 
-import '../styles/czi-frag.css';
-
 class Frag extends React.Component<
   /* eslint-disable  @typescript-eslint/no-explicit-any */ any,
   /* eslint-disable  @typescript-eslint/no-explicit-any */ any

--- a/src/ui/icon.tsx
+++ b/src/ui/icon.tsx
@@ -88,16 +88,15 @@ class Icon extends React.PureComponent {
       }
     }
 
-     let imgStyle: React.CSSProperties = {
+    let imgStyle: React.CSSProperties = {
     width: '100%',
     height: '100%'
   };
- if (type === 'icon_edit') {
+  if (type === 'icon_edit') {
     imgStyle = {
       width: 'auto',
-      height: '32px',
-      marginLeft: '-11px',
-      marginTop: '-6px'
+      height: '30px',
+      marginLeft: '-3px',
     };
   }
  

--- a/src/ui/icon.tsx
+++ b/src/ui/icon.tsx
@@ -8,10 +8,6 @@ import React from 'react';
 import canUseCSSFont from '../canUseCSSFont';
 import {ThemeContext} from '@modusoperandi/licit-ui-commands';
 
-import '../styles/czi-icon.css';
-
-import '../styles/icon-font.css';
-
 const cached = {};
 
 const CSS_FONT = 'Material Icons';
@@ -99,9 +95,9 @@ class Icon extends React.PureComponent {
  if (type === 'icon_edit') {
     imgStyle = {
       width: 'auto',
-      height: '19px',
-      marginLeft: '-10px',
-      marginTop: '-5px'
+      height: '32px',
+      marginLeft: '-11px',
+      marginTop: '-6px'
     };
   }
  

--- a/src/ui/linkTooltip.tsx
+++ b/src/ui/linkTooltip.tsx
@@ -10,8 +10,6 @@ import scrollIntoView from 'smooth-scroll-into-view-if-needed';
 import sanitizeURL from '../sanitizeURL';
 import { CustomButton } from '@modusoperandi/licit-ui-commands';
 
-import '../styles/czi-link-tooltip.css';
-
 function isBookMarkHref(href: string): boolean {
   return !!href && href.indexOf('#') === 0 && href.length >= 2;
 }

--- a/src/ui/linkURLEditor.tsx
+++ b/src/ui/linkURLEditor.tsx
@@ -12,8 +12,6 @@ import {
   preventEventDefault,
 } from '@modusoperandi/licit-ui-commands';
 
-import '../styles/czi-form.css';
-import '../styles/czi-image-url-editor.css';
 import { UICommand } from '@modusoperandi/licit-doc-attrs-step';
 type LinkURLEditorProps = {
   href;

--- a/src/ui/listTypeButton.tsx
+++ b/src/ui/listTypeButton.tsx
@@ -15,7 +15,6 @@ import {
 } from '@modusoperandi/licit-ui-commands';
 import uuid from './uuid';
 import ListTypeMenu from './listTypeMenu';
-import '../styles/czi-custom-menu-button.css';
 import {UICommand} from '@modusoperandi/licit-doc-attrs-step';
 
 type ListTypeButtonType = {

--- a/src/ui/listTypeMenu.tsx
+++ b/src/ui/listTypeMenu.tsx
@@ -9,7 +9,6 @@ import {EditorState} from 'prosemirror-state';
 import {Transform} from 'prosemirror-transform';
 import {EditorView} from 'prosemirror-view';
 import uuid from './uuid';
-import '../styles/listType.css';
 
 // [FS] IRAD-1039 2020-09-24
 // UI to show the list buttons

--- a/src/ui/tableCellMenu.tsx
+++ b/src/ui/tableCellMenu.tsx
@@ -11,8 +11,6 @@ import CommandMenuButton from './commandMenuButton';
 import {TABLE_COMMANDS_GROUP} from './editorToolbarConfig';
 import Icon from './icon';
 
-import '../styles/czi-table-cell-menu.css';
-
 type TableCellMenuProps = {
   editorState: EditorState;
   editorView: EditorView;

--- a/src/ui/tableGridSizeEditor.tsx
+++ b/src/ui/tableGridSizeEditor.tsx
@@ -15,8 +15,6 @@ import {
   clamp,
 } from '@modusoperandi/licit-ui-commands';
 
-import '../styles/czi-table-grid-size-editor.css';
-
 type TableGridSizeEditorProps = {
   close?: (val: TableGridSizeEditorState) => void;
   x?;

--- a/src/ui/uuid.ts
+++ b/src/ui/uuid.ts
@@ -4,7 +4,6 @@
  */
 
 import {v1 as uuidv1} from 'uuid';
-import '../styles/czi-custom-button.css';
 
 export default function uuid(): string {
   return uuidv1() as string;


### PR DESCRIPTION
1. Found the CSS imports in the breaking_changes_tiptap branch and have removed them from the TS/TSX files

2. Fixed the issue : Using the Tab key for indentation displays numbering incorrectly (e.g., “2” instead of “1.1”)
3.  Fixed the issue : When pressing the Tab key, indent is getting added to paragraph instead of inserting a tab space