### PR TITLE
Page Layout menu Item should be removed from Edit Menu. Function menu option is resident in Document View 3-dot menu.

### DIFF
--- a/src/ui/editorToolbarConfig.ts
+++ b/src/ui/editorToolbarConfig.ts
@@ -57,7 +57,6 @@ export function isExpandButton(title: string): boolean {
 }
 const {
   CLEAR_FORMAT,
-  DOC_LAYOUT,
   EM,
   HISTORY_REDO,
   HISTORY_UNDO,

--- a/src/ui/editorToolbarConfig.ts
+++ b/src/ui/editorToolbarConfig.ts
@@ -192,8 +192,4 @@ export const COMMAND_GROUPS: CommandGroup[] | UICommand[] = [
     '[grid_on] Table...': TABLE_COMMANDS_GROUP,
     '[hr] Horizontal line': HR,
   },
-  {
-    '[settings_overscan] Page layout': DOC_LAYOUT,
-  },
-
 ];


### PR DESCRIPTION
Page Layout menu Item should be removed from Edit Menu. Function menu option is resident in Document View 3-dot menu.